### PR TITLE
Add an Update Message command

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -83,6 +83,25 @@ pub enum Commands {
         #[arg(short, long)]
         new_update_authority: Option<Pubkey>,
     },
+    UpdateMsg {
+        /// Mint of the collection parent NFT.
+        #[arg(short, long)]
+        collection_mint: Pubkey,
+
+        /// Rule set to use for the collection.
+        #[arg(short = 'R', long)]
+        rule_set: Option<Pubkey>,
+
+        /// New number of items in the collection.
+        #[arg(short, long)]
+        size: Option<u32>,
+
+        /// New update authority for items in the collection.
+        #[arg(short, long)]
+        new_update_authority: Option<Pubkey>,
+
+        authority_pubkey: Pubkey,
+    },
     Start {
         /// Mint of the collection parent NFT.
         #[arg(short, long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,21 @@ async fn main() -> Result<()> {
             size,
             new_update_authority,
         ),
+        Commands::UpdateMsg {
+            collection_mint,
+            rule_set,
+            size,
+            new_update_authority,
+            authority_pubkey,
+        } => process_update_msg(
+            keypair_path,
+            rpc_url,
+            collection_mint,
+            rule_set,
+            size,
+            new_update_authority,
+            authority_pubkey,
+        ),
         Commands::Start { collection_mint } => {
             process_start(keypair_path, rpc_url, collection_mint)
         }

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -192,7 +192,6 @@ pub fn update_msg(params: UpdateMsgParams) -> Result<String> {
         new_update_authority,
     };
 
-    // TODO: swap the authority pubkey with the vault pubkey
     let instruction =
         mpl_migration_validator::instruction::update(authority_pubkey, migration_state, args);
 

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -167,6 +167,39 @@ pub fn update(params: UpdateParams) -> Result<Signature> {
     Ok(sig)
 }
 
+pub struct UpdateMsgParams<'a> {
+    pub authority: &'a Keypair,
+    pub authority_pubkey: Pubkey,
+    pub migration_state: Pubkey,
+    pub rule_set: Option<Pubkey>,
+    pub collection_size: Option<u32>,
+    pub new_update_authority: Option<Pubkey>,
+}
+
+pub fn update_msg(params: UpdateMsgParams) -> Result<String> {
+    let UpdateMsgParams {
+        authority,
+        authority_pubkey,
+        migration_state,
+        rule_set,
+        collection_size,
+        new_update_authority,
+    } = params;
+
+    let args = UpdateArgs {
+        rule_set,
+        collection_size,
+        new_update_authority,
+    };
+
+    // TODO: swap the authority pubkey with the vault pubkey
+    let instruction =
+        mpl_migration_validator::instruction::update(authority_pubkey, migration_state, args);
+
+    let message = Message::new(&[instruction], Some(&authority.pubkey()));
+    Ok(bs58::encode(message.serialize()).into_string())
+}
+
 pub struct StartParams<'a> {
     pub client: &'a RpcClient,
     pub authority: &'a Keypair,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -25,9 +25,9 @@ use tokio::sync::{Mutex, Semaphore};
 
 use crate::{
     methods::{
-        close, get_state, initialize, initialize_msg, migrate_item, start, update, CloseParams,
-        GetStateParams, InitializeMsgParams, InitializeParams, MigrateParams, StartParams,
-        UpdateParams,
+        close, get_state, initialize, initialize_msg, migrate_item, start, update, update_msg,
+        CloseParams, GetStateParams, InitializeMsgParams, InitializeParams, MigrateParams,
+        StartParams, UpdateMsgParams, UpdateParams,
     },
     setup,
     utils::{create_progress_bar, get_cluster, get_nft_token_account, spinner_with_style},
@@ -275,6 +275,43 @@ pub fn process_update(
         "Updated migration state successfully in tx: {}",
         style(link).green()
     );
+
+    Ok(())
+}
+
+pub fn process_update_msg(
+    keypair: Option<PathBuf>,
+    rpc_url: Option<String>,
+    collection_mint: Pubkey,
+    rule_set: Option<Pubkey>,
+    collection_size: Option<u32>,
+    new_update_authority: Option<Pubkey>,
+    authority_pubkey: Pubkey,
+) -> Result<()> {
+    let config = setup::CliConfig::new(keypair, rpc_url)?;
+
+    let (migration_state, _) = find_migration_state_pda(&collection_mint);
+
+    let params = UpdateMsgParams {
+        authority: &config.keypair,
+        authority_pubkey,
+        migration_state,
+        collection_size,
+        rule_set,
+        new_update_authority,
+    };
+    let spinner = spinner_with_style();
+    spinner.set_message("Updating migration state...");
+    let tx = update_msg(params)?;
+    spinner.finish();
+
+    // let cluster = get_cluster(&config.client)?;
+    // let link = format!("https://explorer.solana.com/tx/{sig}?cluster={cluster}");
+    // println!(
+    //     "Updated migration state successfully in tx: {}",
+    //     style(link).green()
+    // );
+    println!("Transaction: {}", style(tx).green());
 
     Ok(())
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -305,12 +305,6 @@ pub fn process_update_msg(
     let tx = update_msg(params)?;
     spinner.finish();
 
-    // let cluster = get_cluster(&config.client)?;
-    // let link = format!("https://explorer.solana.com/tx/{sig}?cluster={cluster}");
-    // println!(
-    //     "Updated migration state successfully in tx: {}",
-    //     style(link).green()
-    // );
     println!("Transaction: {}", style(tx).green());
 
     Ok(())


### PR DESCRIPTION
The update-msg command currently uses the --authority-pubkey as the expected signer, which is useful for creating transactions that need to be signed by a keypair that the user does not own.

This design choice may be changed to be consistent with the other commands in the bin, but adding optional authority pubkeys may be something to consider.